### PR TITLE
Fix use proximity

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,7 @@ import useProximity from "./hooks/useProximity";
 function App() {
   const ref = useRef<HTMLDivElement>(null);
 
-  const [element, setElement] = useState<HTMLDivElement | null>(null);
-
-  const proximity = useProximity(element);
-
-  useLayoutEffect(() => {
-    if (ref.current) setElement(ref.current);
-  }, []);
+  const proximity = useProximity(ref);
 
   return <div ref={ref}>{proximity}</div>;
 }

--- a/src/components/Render.tsx
+++ b/src/components/Render.tsx
@@ -4,13 +4,7 @@ import useProximity from "../hooks/useProximity";
 const Render: FC<any> = ({ children }) => {
   const ref = useRef<HTMLDivElement>(null);
 
-  const [element, setElement] = useState<HTMLDivElement | null>(null);
-
-  const proximity = useProximity(element);
-
-  useLayoutEffect(() => {
-    if (ref.current) setElement(ref.current);
-  }, []);
+  const proximity = useProximity(ref);
 
   return (
     <div ref={ref}>{proximity >= 0 && proximity <= 2 ? children : null}</div>

--- a/src/hooks/useProximity.ts
+++ b/src/hooks/useProximity.ts
@@ -1,7 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { RefObject, useEffect, useLayoutEffect, useState } from "react";
 
-const useProximity = (element: HTMLElement | null) => {
+const useProximity = (ref: RefObject<any>) => {
   const [proximity, setProximity] = useState(0);
+
+  const [element, setElement] = useState<HTMLElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (ref) setElement(ref.current);
+  }, []);
 
   const handleProximity = () =>
     setProximity(

--- a/src/test-components/BackgroundChange.tsx
+++ b/src/test-components/BackgroundChange.tsx
@@ -20,7 +20,7 @@ const BackgroundChange: FC<any> = ({ children }) => {
   const direction = useDirection();
 
   const ref = useRef<HTMLDivElement>(null);
-  const proximity = useProximity(ref.current);
+  const proximity = useProximity(ref);
 
   useEffect(() => {
     switch (direction) {


### PR DESCRIPTION
Now all the logic to initialize the useProximity is on the customHook, now you only need to pass a reference of a HTMLElement to work